### PR TITLE
use knu's path in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Finally, you will need a working installation of PostgreSQL. See [asdf-postgres]
 ## Install
 
 ```
-asdf plugin-add postgis https://github.com/francois/asdf-postgis.git
+asdf plugin-add postgis https://github.com/knu/asdf-postgis.git
 ```
 
 ## ASDF options


### PR DESCRIPTION
Given that you have fixed the installation problems for this plugin, I think it makes sense to have your README reflect how to use your version instead of continuing to point to the abandoned version.
