### PR TITLE
Fix install due to wrong postgres version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -11,7 +11,7 @@ install_postgis() {
   if [ "$manager" = "mise" ]; then
     postgres_version=$(mise current postgres 2>/dev/null)
   else # asdf ("bash")
-    postgres_version=$(asdf current postgres 2>/dev/null | awk '{print $2}')
+    postgres_version=$(asdf current postgres 2>/dev/null | tail -n 1 | awk '{print $2}')
   fi
 
   (


### PR DESCRIPTION
Why:
* The install is failing due with the following error:
```
checking for pg_config... /Users/frm/.asdf/shims/pg_config
No version is set for command pg_config
Consider adding one of the following versions in your config file at /Users/frm/.asdf/downloads/postgis/3.5.3/.tool-versions
configure: error: the PGXS Makefile postgres 17.5
postgres 16.4
postgres 16.0 cannot be found. Please install the PostgreSQL server development packages and re-run configure.
error installing version: failed to run install callback: exit status 1
```

* This is due to the generated `.tool-versions` having the following content:
  ```
  postgres
  Version 17.5
  ```
* That content is generated because `asdf current <plugin>` has a header (at least in 0.17+) and both lines get picked up by `awk`.
* What we actually want is the following `.tool-versions`:
  ```
  postgres 17.5
  ```

How:
* Ensuring the header is ignored when determining the postgres version

<img width="428" alt="image" src="https://github.com/user-attachments/assets/4f472b2e-216c-42a6-b2cc-cc8a7110a993" />
<img width="564" alt="image" src="https://github.com/user-attachments/assets/063f291c-87c1-4eb1-bf0b-de74556f4825" />
